### PR TITLE
Inherit database from the existing connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .byebug_history
 tags
 departure_error.log
+.idea

--- a/lib/departure.rb
+++ b/lib/departure.rb
@@ -73,7 +73,7 @@ module Departure
       # instead of the current adapter.
       def reconnect_with_percona
         connection_config = ActiveRecord::Base
-          .connection_config.merge(adapter: 'percona')
+          .connection_config.merge(adapter: 'percona', database: ActiveRecord::Base.connection.current_database)
         ActiveRecord::Base.establish_connection(connection_config)
       end
     end


### PR DESCRIPTION
We have to set the right database when reconnecting to mysql using percona.
Original behavior:
Connect to the database found in the config file
After change:
We connect to the database found in the ActiveRecord::Base object. Since departure is always reconnecting, this object should always contain the correct database name