### PR TITLE
Support pt-osc with apartment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .byebug_history
 tags
 departure_error.log
+.idea

--- a/lib/departure.rb
+++ b/lib/departure.rb
@@ -73,8 +73,8 @@ module Departure
       # instead of the current adapter.
       def reconnect_with_percona
         connection_config = ActiveRecord::Base
-          .connection_config.merge(adapter: 'percona')
-        ActiveRecord::Base.establish_connection(connection_config, database: ActiveRecord::Base.connection.current_database)
+          .connection_config.merge(adapter: 'percona', database: ActiveRecord::Base.connection.current_database)
+        ActiveRecord::Base.establish_connection(connection_config)
       end
     end
   end

--- a/lib/departure.rb
+++ b/lib/departure.rb
@@ -74,7 +74,7 @@ module Departure
       def reconnect_with_percona
         connection_config = ActiveRecord::Base
           .connection_config.merge(adapter: 'percona')
-        ActiveRecord::Base.establish_connection(connection_config)
+        ActiveRecord::Base.establish_connection(connection_config, database: ActiveRecord::Base.connection.current_database)
       end
     end
   end

--- a/lib/departure/version.rb
+++ b/lib/departure/version.rb
@@ -1,3 +1,3 @@
 module Departure
-  VERSION = '4.0.1'.freeze
+  VERSION = '4.0.2'.freeze
 end


### PR DESCRIPTION
We have to set the right database when reconnecting to mysql using percona.
Original behavior:
Connect to the database found in the config file
After change:
We connect to the database found in the ActiveRecord::Base object. Since departure is always reconnecting, this object should always contain the correct database name